### PR TITLE
Test that CollectionChanged event is fired when actions are executed

### DIFF
--- a/src/UndoFramework.UnitTests/ActionManagerTests.cs
+++ b/src/UndoFramework.UnitTests/ActionManagerTests.cs
@@ -70,5 +70,40 @@ namespace UndoFramework.UnitTests
                 { action1, action2 }));
             Assert.AreEqual(0, actionManager.EnumRedoableActions().Count());
         }
+
+        [TestMethod]
+        public void ShouldRaiseCollectionChangedEventForFirstAction()
+        {
+            int collectionChanges = 0;
+
+            var actionManager = new ActionManager();
+            actionManager.CollectionChanged += (sender, e) =>
+            {
+                collectionChanges++;
+            };
+
+            var action = new CallMethodAction(() => { }, () => { });
+            actionManager.Execute(action);
+            Assert.AreEqual(1, collectionChanges);
+        }
+
+        [TestMethod]
+        public void ShouldRaiseCollectionChangedEventForFirstTransaction()
+        {
+            int collectionChanges = 0;
+
+            var actionManager = new ActionManager();
+            actionManager.CollectionChanged += (sender, e) =>
+            {
+                collectionChanges++;
+            };
+
+            var action = new CallMethodAction(() => { }, () => { });
+            var transaction = actionManager.CreateTransaction();
+            transaction.Add(action);
+            transaction.Commit();
+            Assert.AreEqual(1, collectionChanges);
+        }
+
     }
 }


### PR DESCRIPTION
I was under the impression that CollectionChanged never got fired for the very first action that was executed. Wrote two test cases and verified that CollectionChanged works correctly. 