### PR TITLE
Upgrade to Dotnet standard 2.0

### DIFF
--- a/src/MinimalSample/MinimalSample.csproj
+++ b/src/MinimalSample/MinimalSample.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MinimalSample</RootNamespace>
     <AssemblyName>MinimalSample</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/UndoFramework.UnitTests/ActionManagerTests.cs
+++ b/src/UndoFramework.UnitTests/ActionManagerTests.cs
@@ -1,14 +1,14 @@
 ﻿using System.Linq;
 using System.Text;
 using GuiLabs.Undo;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace UndoFramework.UnitTests
 {
-    [TestClass]
+    [TestFixture]
     public class ActionManagerTests
     {
-        [TestMethod]
+        [Test]
         public void TestEndToEnd1()
         {
             var actionManager = new ActionManager();
@@ -71,7 +71,7 @@ namespace UndoFramework.UnitTests
             Assert.AreEqual(0, actionManager.EnumRedoableActions().Count());
         }
 
-        [TestMethod]
+        [Test]
         public void ShouldRaiseCollectionChangedEventForFirstAction()
         {
             int collectionChanges = 0;
@@ -87,7 +87,7 @@ namespace UndoFramework.UnitTests
             Assert.AreEqual(1, collectionChanges);
         }
 
-        [TestMethod]
+        [Test]
         public void ShouldRaiseCollectionChangedEventForFirstTransaction()
         {
             int collectionChanges = 0;

--- a/src/UndoFramework.UnitTests/ActionsTests.cs
+++ b/src/UndoFramework.UnitTests/ActionsTests.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using GuiLabs.Undo;
-
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace UndoFramework.UnitTests
 {
-    [TestClass]
+    [TestFixture]
     public class ActionsTests
     {
-        [TestMethod]
+        [Test]
         public void AddItemActionWorks()
         {
             List<string> list = new List<string>();
@@ -23,7 +22,7 @@ namespace UndoFramework.UnitTests
             Assert.AreEqual("foo", list[0]);
         }
 
-        [TestMethod]
+        [Test]
         public void CallMethodActionWorks()
         {
             bool capturedFlag = false;
@@ -39,7 +38,7 @@ namespace UndoFramework.UnitTests
             Assert.IsTrue(capturedFlag);
         }
 
-        [TestMethod]
+        [Test]
         public void SetPropertyActionWorks()
         {
             var instance = new Exception();

--- a/src/UndoFramework.UnitTests/TransactionTests.cs
+++ b/src/UndoFramework.UnitTests/TransactionTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using GuiLabs.Undo;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace UndoFramework.UnitTests
 {
-    [TestClass]
+    [TestFixture]
     public class TransactionTests
     {
         public TestContext TestContext { get; set; }
@@ -31,7 +31,7 @@ namespace UndoFramework.UnitTests
         //
         #endregion
 
-        [TestMethod]
+        [Test]
         public void Transactions()
         {
             var instance = new Exception();
@@ -54,7 +54,7 @@ namespace UndoFramework.UnitTests
             Assert.AreEqual(instance.Source, "red");
         }
 
-        [TestMethod]
+        [Test]
         public void ThrowingActionInsideTransactionWillRollback()
         {
             ActionManager am = new ActionManager();

--- a/src/UndoFramework.UnitTests/UndoFramework.UnitTests.csproj
+++ b/src/UndoFramework.UnitTests/UndoFramework.UnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -7,8 +8,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>UndoFramework.UnitTests</RootNamespace>
     <AssemblyName>UndoFramework.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,9 +29,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActionManagerTests.cs" />
@@ -42,6 +44,9 @@
       <Project>{211753FC-8C4D-4F05-AB4B-130FABECF30E}</Project>
       <Name>UndoFramework</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/UndoFramework.UnitTests/packages.config
+++ b/src/UndoFramework.UnitTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
+</packages>

--- a/src/UndoFramework/UndoFramework.csproj
+++ b/src/UndoFramework/UndoFramework.csproj
@@ -1,33 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <SrcRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Common.props))</SrcRoot>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <PropertyGroup>
     <ProjectGuid>{211753FC-8C4D-4F05-AB4B-130FABECF30E}</ProjectGuid>
     <AssemblyName>GuiLabs.Undo</AssemblyName>
     <AppDesignerFolder>Properties</AppDesignerFolder>
   </PropertyGroup>
-  <Import Project="$(SrcRoot)\Common.props" />
-  <ItemGroup>
-    <Compile Include="AbstractAction.cs" />
-    <Compile Include="ActionManager.cs" />
-    <Compile Include="ActionManagerExtensions.cs" />
-    <Compile Include="Actions\AddItemAction.cs" />
-    <Compile Include="Actions\CallMethodAction.cs" />
-    <Compile Include="Actions\SetPropertyAction.cs" />
-    <Compile Include="History\IActionHistory.cs" />
-    <Compile Include="History\SimpleHistory.cs" />
-    <Compile Include="History\SimpleHistoryNode.cs" />
-    <Compile Include="IAction.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Transaction.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
   <ItemGroup>
     <None Include="Guilabs.Undo.nuspec" />
   </ItemGroup>
-  <Import Project="$(SrcRoot)\Common.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/src/WinFormsSample/MultilevelUndoTextbox.cs
+++ b/src/WinFormsSample/MultilevelUndoTextbox.cs
@@ -47,6 +47,7 @@ namespace WinFormsSample
             guard = true;
             multilevelTextboxActionManager.Undo();
             UpdateMultilevelUndoRedoButtons();
+            oldText = MultilevelTextbox.Text;
             guard = false;
         }
 
@@ -59,6 +60,7 @@ namespace WinFormsSample
             guard = true;
             multilevelTextboxActionManager.Redo();
             UpdateMultilevelUndoRedoButtons();
+            oldText = MultilevelTextbox.Text;
             guard = false;
         }
     }

--- a/src/WinFormsSample/WinFormsSample.csproj
+++ b/src/WinFormsSample/WinFormsSample.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WinFormsSample</RootNamespace>
     <AssemblyName>WinFormsSample</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
- Upgrade undo framework to dotnet standard 2.0
- Tests- Move from MSTest to NUnit (to allow running tests on mac/linux)
- Upgrade samples to dotnet 4.7.1 (to be able to reference undo framework)
- Fix #4 